### PR TITLE
feat: Implement multi-type search functionality

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,10 +4,17 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import HomeScreen from '@screens/HomeScreen';
 import RepoDetailScreen from '@screens/RepoDetailScreen';
+import IssueDetailScreen from './src/screens/IssueDetailScreen';
+import PRDetailScreen from './src/screens/PRDetailScreen';
+import CodeDetailScreen from './src/screens/CodeDetailScreen';
+import { GitHubRepo, GitHubIssue, GitHubPR, GitHubCode } from './src/models';
 
 export type RootStackParamList = {
   Home: undefined;
-  RepoDetail: { repo: any }; // Replace 'any' with a proper model later
+  RepoDetail: { repo: GitHubRepo }; 
+  IssueDetail: { issue: GitHubIssue }; 
+  PRDetail: { pr: GitHubPR }; 
+  CodeDetail: { code: GitHubCode }; 
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -32,6 +39,21 @@ const App = () => {
           name="RepoDetail"
           component={RepoDetailScreen}
           options={{ title: 'Repository Details' }}
+        />
+        <Stack.Screen
+          name="IssueDetail"
+          component={IssueDetailScreen}
+          options={{ title: 'Issue Details' }}
+        />
+        <Stack.Screen
+          name="PRDetail"
+          component={PRDetailScreen}
+          options={{ title: 'Pull Request Details' }}
+        />
+        <Stack.Screen
+          name="CodeDetail"
+          component={CodeDetailScreen}
+          options={{ title: 'Code Details' }}
         />
       </Stack.Navigator>
     </NavigationContainer>

--- a/src/managers/GitHubAPIManager.ts
+++ b/src/managers/GitHubAPIManager.ts
@@ -1,16 +1,69 @@
 import axios from 'axios';
-import { GitHubRepo } from '@models/GitHubRepo';
+import { GitHubRepo, GitHubIssue, GitHubPR, GitHubCode } from '@models/index';
+
+const GITHUB_API_BASE_URL = 'https://api.github.com/search';
 
 export const GitHubAPIManager = {
   async searchRepos(query: string, page: number = 1, per_page: number = 20): Promise<GitHubRepo[]> {
     const response = await axios.get(
-      `https://api.github.com/search/repositories`,
+      `${GITHUB_API_BASE_URL}/repositories`,
       {
         params: {
           q: query,
           page,
           per_page,
         },
+      }
+    );
+    return response.data.items;
+  },
+
+  async searchIssues(query: string, page: number = 1, per_page: number = 20): Promise<GitHubIssue[]> {
+    const response = await axios.get(
+      `${GITHUB_API_BASE_URL}/issues`,
+      {
+        params: {
+          q: query,
+          page,
+          per_page,
+        },
+      }
+    );
+    return response.data.items;
+  },
+
+  async searchPRs(query: string, page: number = 1, per_page: number = 20): Promise<GitHubPR[]> {
+    // Note: GitHub API uses the same endpoint for issues and PRs.
+    // We can differentiate by adding 'is:pr' or 'is:issue' to the query.
+    // For simplicity here, we'll assume the query will include 'is:pr' when PRs are desired.
+    // Alternatively, the component calling this can append ' is:pr' to the query.
+    const response = await axios.get(
+      `${GITHUB_API_BASE_URL}/issues`, // Same endpoint as issues
+      {
+        params: {
+          q: `${query} is:pr`, // Added 'is:pr' to filter for pull requests
+          page,
+          per_page,
+        },
+      }
+    );
+    return response.data.items;
+  },
+
+  async searchCode(query: string, page: number = 1, per_page: number = 20): Promise<GitHubCode[]> {
+    const response = await axios.get(
+      `${GITHUB_API_BASE_URL}/code`,
+      {
+        params: {
+          q: query,
+          page,
+          per_page,
+        },
+        // Important: GitHub API for code search requires authentication and
+        // a specific Accept header for text-match metadata if desired.
+        // For now, this basic version won't include authentication or special headers.
+        // This might lead to lower rate limits or different response structures
+        // if authentication is strictly required for some queries.
       }
     );
     return response.data.items;

--- a/src/models/GitHubCode.ts
+++ b/src/models/GitHubCode.ts
@@ -1,0 +1,16 @@
+export interface GitHubCode {
+  name: string;
+  path: string;
+  sha: string;
+  html_url: string;
+  repository: {
+    id: number;
+    name: string;
+    full_name: string;
+    html_url: string;
+    owner: {
+      login: string;
+      avatar_url: string;
+    };
+  };
+}

--- a/src/models/GitHubIssue.ts
+++ b/src/models/GitHubIssue.ts
@@ -1,0 +1,15 @@
+export interface GitHubIssue {
+  id: number;
+  html_url: string;
+  title: string;
+  user: {
+    login: string;
+    avatar_url: string;
+  };
+  state: string;
+  comments: number;
+  created_at: string;
+  updated_at: string;
+  repository_url: string; // To get repository information if needed
+  number: number;
+}

--- a/src/models/GitHubPR.ts
+++ b/src/models/GitHubPR.ts
@@ -1,0 +1,15 @@
+export interface GitHubPR {
+  id: number;
+  html_url: string;
+  title: string;
+  user: {
+    login: string;
+    avatar_url: string;
+  };
+  state: string;
+  created_at: string;
+  updated_at: string;
+  merged_at?: string | null; // PRs may not be merged
+  repository_url: string; // To get repository information if needed
+  number: number;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,0 +1,4 @@
+export * from './GitHubRepo';
+export * from './GitHubIssue';
+export * from './GitHubPR';
+export * from './GitHubCode';

--- a/src/screens/CodeDetailScreen.tsx
+++ b/src/screens/CodeDetailScreen.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../App'; // Assuming App.tsx is two levels up
+import { GitHubCode } from '../models'; // Assuming models are one level up then into models
+
+type CodeDetailScreenProps = NativeStackScreenProps<RootStackParamList, 'CodeDetail'>;
+
+const CodeDetailScreen: React.FC<CodeDetailScreenProps> = ({ route }) => {
+  const { code } = route.params;
+
+  return (
+    <ScrollView style={styles.container}>
+      <Text style={styles.title}>Code Search Result</Text>
+      <Text style={styles.info}>Name: {code.name}</Text>
+      <Text style={styles.info}>Path: {code.path}</Text>
+      <Text style={styles.info}>Repository: {code.repository.full_name}</Text>
+      <Text style={styles.info}>SHA: {code.sha}</Text>
+      {/* Potentially display code content or link to it */}
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 16,
+  },
+  info: {
+    fontSize: 16,
+    marginBottom: 8,
+  },
+});
+
+export default CodeDetailScreen;

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   View,
   Text,
@@ -10,94 +10,190 @@ import {
   Button,
 } from 'react-native';
 import { GitHubAPIManager } from '@managers/GitHubAPIManager';
-import { GitHubRepo } from '@models/GitHubRepo';
+import { GitHubRepo, GitHubIssue, GitHubPR, GitHubCode } from '@models/index';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../App';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
+enum SearchType {
+  REPOSITORIES = 'Repositories',
+  ISSUES = 'Issues',
+  PRS = 'Pull Requests',
+  CODE = 'Code',
+}
+
 const HomeScreen: React.FC<Props> = ({ navigation }) => {
   const [query, setQuery] = useState('');
-  const [repos, setRepos] = useState<GitHubRepo[]>([]);
+  const [searchType, setSearchType] = useState<SearchType>(SearchType.REPOSITORIES);
+  const [results, setResults] = useState<Array<GitHubRepo | GitHubIssue | GitHubPR | GitHubCode>>([]);
   const [loading, setLoading] = useState(false);
   const [page, setPage] = useState(1);
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const PER_PAGE = 20;
 
-  useEffect(() => {
-    if (query.length >= 3) {
-      handleSearch();
-    } else {
-      setRepos([]);
-      setPage(1);
-      setHasMore(true);
+  const executeSearch = useCallback(async (currentPage: number) => {
+    const isQueryValidForSearch = searchType === SearchType.CODE ? query.length > 0 : query.length >= 3;
+    if (!isQueryValidForSearch) {
+        return null;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query]);
+    let apiResults;
+    try {
+      switch (searchType) {
+        case SearchType.ISSUES:
+          apiResults = await GitHubAPIManager.searchIssues(query, currentPage, PER_PAGE);
+          break;
+        case SearchType.PRS:
+          apiResults = await GitHubAPIManager.searchPRs(query, currentPage, PER_PAGE);
+          break;
+        case SearchType.CODE:
+          apiResults = await GitHubAPIManager.searchCode(query, currentPage, PER_PAGE);
+          break;
+        case SearchType.REPOSITORIES:
+        default:
+          apiResults = await GitHubAPIManager.searchRepos(query, currentPage, PER_PAGE);
+          break;
+      }
+      return apiResults;
+    } catch (error) {
+      console.error(`Error fetching ${searchType}:`, error);
+      return null;
+    }
+  }, [query, searchType, PER_PAGE]);
 
-  const handleSearch = async () => {
-    if (query.length < 3) return;
+  const handleSearch = useCallback(async () => {
+    const isQueryValidForSearch = searchType === SearchType.CODE ? query.length > 0 : query.length >= 3;
+    if (!isQueryValidForSearch) {
+        setResults([]);
+        setPage(1);
+        setHasMore(true);
+        setLoading(false);
+        return;
+    }
+
     setLoading(true);
+    setResults([]); 
     setPage(1);
-    setHasMore(true);
-    try {
-      const results = await GitHubAPIManager.searchRepos(query, 1, PER_PAGE);
-      setRepos(results);
-      setHasMore(results.length === PER_PAGE);
-    } catch (error) {
-      console.error('Error fetching repos:', error);
-    } finally {
-      setLoading(false);
+    const apiResults = await executeSearch(1);
+    if (apiResults) {
+      setResults(apiResults);
+      setHasMore(apiResults.length === PER_PAGE);
+    } else {
+      setResults([]);
+      setHasMore(false);
     }
-  };
+    setLoading(false);
+  }, [executeSearch, PER_PAGE, searchType, query]);
 
-  const loadMore = async () => {
-    if (!query.trim() || loadingMore || loading || !hasMore) return;
-    const nextPage = page + 1;
+  const loadMore = useCallback(async () => {
+    const isQueryValidForSearch = searchType === SearchType.CODE ? query.length > 0 : query.length >= 3;
+    if (!isQueryValidForSearch || loadingMore || !hasMore || loading) return;
+    
     setLoadingMore(true);
-    try {
-      const results = await GitHubAPIManager.searchRepos(query, nextPage, PER_PAGE);
-      setRepos(prev => [...prev, ...results]);
+    const nextPage = page + 1;
+    const apiResults = await executeSearch(nextPage);
+    if (apiResults && apiResults.length > 0) {
+      setResults(prev => [...prev, ...apiResults]);
       setPage(nextPage);
-      setHasMore(results.length === PER_PAGE);
-    } catch (error) {
-      console.error('Error fetching more repos:', error);
-    } finally {
-      setLoadingMore(false);
+      setHasMore(apiResults.length === PER_PAGE);
+    } else if (apiResults && apiResults.length === 0) {
+      setHasMore(false);
     }
+    setLoadingMore(false);
+  }, [query, searchType, loadingMore, hasMore, loading, page, executeSearch, PER_PAGE]);
+
+
+  useEffect(() => {
+    handleSearch();
+  }, [query, searchType, handleSearch]);
+
+  const renderItem = ({ item }: { item: GitHubRepo | GitHubIssue | GitHubPR | GitHubCode }) => {
+    let title = '';
+    let detail = '';
+    let tappable = false;
+
+    if ('full_name' in item) { // GitHubRepo
+      title = item.full_name;
+      detail = item.description;
+      tappable = true;
+    } else if ('title' in item) { // GitHubIssue or GitHubPR
+      title = item.title;
+      detail = `#${item.number} opened by ${item.user.login} | State: ${item.state}`;
+    } else if ('path' in item) { // GitHubCode
+      title = item.name;
+      detail = `${item.path} in ${item.repository.full_name}`;
+    }
+
+    return (
+      <TouchableOpacity
+        style={styles.repoItem}
+        onPress={() => {
+          if (tappable && 'full_name' in item) {
+            navigation.navigate('RepoDetail', { repo: item as GitHubRepo });
+          }
+        }}
+        disabled={!tappable}
+      >
+        <Text style={styles.repoName}>{title}</Text>
+        {detail ? <Text numberOfLines={2}>{detail}</Text> : null}
+      </TouchableOpacity>
+    );
   };
 
-  const renderItem = ({ item }: { item: GitHubRepo }) => (
-    <TouchableOpacity
-      style={styles.repoItem}
-      onPress={() => navigation.navigate('RepoDetail', { repo: item })}
-    >
-      <Text style={styles.repoName}>{item.full_name}</Text>
-      <Text numberOfLines={2}>{item.description}</Text>
-    </TouchableOpacity>
-  );
+  const getPlaceholderText = () => {
+    switch (searchType) {
+      case SearchType.ISSUES:
+        return 'Search GitHub Issues (e.g., react type:issue)';
+      case SearchType.PRS:
+        return 'Search GitHub Pull Requests (e.g., auth type:pr)';
+      case SearchType.CODE:
+        return 'Search GitHub Code (e.g., useState filename:tsx)';
+      case SearchType.REPOSITORIES:
+      default:
+        return 'Search GitHub Repositories (e.g., awesome-react)';
+    }
+  };
+  
+  const getItemKey = (item: GitHubRepo | GitHubIssue | GitHubPR | GitHubCode) => {
+    if ('sha' in item && !('id' in item)) { // GitHubCode
+        return item.sha;
+    }
+    return (item as {id: number}).id.toString(); // GitHubRepo, GitHubIssue, GitHubPR
+  };
 
   return (
     <View style={styles.container}>
+      <View style={styles.searchTypeContainer}>
+        {Object.values(SearchType).map(type => (
+          <Button
+            key={type}
+            title={type}
+            onPress={() => setSearchType(type)}
+            color={searchType === type ? '#007AFF' : '#AAA'}
+          />
+        ))}
+      </View>
       <TextInput
-        placeholder="Search GitHub Repositories"
+        placeholder={getPlaceholderText()}
         style={styles.input}
         value={query}
         onChangeText={setQuery}
         returnKeyType="search"
+        onSubmitEditing={handleSearch}
       />
-      {loading ? (
+      {loading && page === 1 && results.length === 0 ? (
         <ActivityIndicator size="large" color="#000" />
       ) : (
         <FlatList
-          data={repos}
-          keyExtractor={(item) => item.id.toString()}
+          data={results}
+          keyExtractor={(item) => getItemKey(item)}
           renderItem={renderItem}
           contentContainerStyle={styles.list}
           onEndReached={loadMore}
           onEndReachedThreshold={0.5}
           ListFooterComponent={loadingMore ? <ActivityIndicator size="small" color="#000" /> : null}
+          ListEmptyComponent={!loading && (searchType === SearchType.CODE ? query.length > 0 : query.length >=3) ? <View style={styles.emptyComponent}><Text>No results found.</Text></View> : null}
         />
       )}
     </View>
@@ -112,14 +208,16 @@ const styles = StyleSheet.create({
     padding: 16,
     backgroundColor: '#fff',
   },
+  searchTypeContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    marginBottom: 12,
+  },
   input: {
     padding: 12,
     borderWidth: 1,
     borderColor: '#ccc',
     borderRadius: 8,
-    marginBottom: 12,
-  },
-  buttonContainer: {
     marginBottom: 12,
   },
   list: {
@@ -132,5 +230,12 @@ const styles = StyleSheet.create({
   },
   repoName: {
     fontWeight: 'bold',
+    marginBottom: 4,
   },
+  emptyComponent: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 50,
+  }
 });

--- a/src/screens/IssueDetailScreen.tsx
+++ b/src/screens/IssueDetailScreen.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../App'; // Assuming App.tsx is two levels up
+import { GitHubIssue } from '../models'; // Assuming models are one level up then into models
+
+type IssueDetailScreenProps = NativeStackScreenProps<RootStackParamList, 'IssueDetail'>;
+
+const IssueDetailScreen: React.FC<IssueDetailScreenProps> = ({ route }) => {
+  const { issue } = route.params;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Issue Details</Text>
+      <Text style={styles.info}>Title: {issue.title}</Text>
+      <Text style={styles.info}>Number: #{issue.number}</Text>
+      <Text style={styles.info}>User: {issue.user.login}</Text>
+      <Text style={styles.info}>State: {issue.state}</Text>
+      {/* Add more details as needed */}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 16,
+  },
+  info: {
+    fontSize: 16,
+    marginBottom: 8,
+  },
+});
+
+export default IssueDetailScreen;

--- a/src/screens/PRDetailScreen.tsx
+++ b/src/screens/PRDetailScreen.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../App'; // Assuming App.tsx is two levels up
+import { GitHubPR } from '../models'; // Assuming models are one level up then into models
+
+type PRDetailScreenProps = NativeStackScreenProps<RootStackParamList, 'PRDetail'>;
+
+const PRDetailScreen: React.FC<PRDetailScreenProps> = ({ route }) => {
+  const { pr } = route.params;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Pull Request Details</Text>
+      <Text style={styles.info}>Title: {pr.title}</Text>
+      <Text style={styles.info}>Number: #{pr.number}</Text>
+      <Text style={styles.info}>User: {pr.user.login}</Text>
+      <Text style={styles.info}>State: {pr.state}</Text>
+      {/* Add more details as needed */}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 16,
+  },
+  info: {
+    fontSize: 16,
+    marginBottom: 8,
+  },
+});
+
+export default PRDetailScreen;


### PR DESCRIPTION
This commit introduces the ability to search for issues, pull requests, and code, in addition to repositories.

Key changes:
- Added data models for GitHub Issues, Pull Requests, and Code.
- Extended GitHubAPIManager to include search methods for these new types.
- Updated HomeScreen UI with a type selector (Repositories, Issues, PRs, Code).
- Modified HomeScreen logic to:
    - Call the appropriate API based on selected type.
    - Render results differently based on their type.
    - Adjust placeholder text and key extraction for different types.
    - Handle different minimum query lengths (3 for most, 1 for code).
- Navigation to detail screen is currently enabled only for repository items.